### PR TITLE
Add minimal multilingual Android skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/build/
+.gradle/
+*.iml
+local.properties
+# Ignore gradle wrapper jar to avoid binary file
+**/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-echo "# potential-succotash" > README.md
-echo "node_modules/" > .gitignore
-git add README.md .gitignore
-git commit -m "Initialisiere das Repository mit README und .gitignore"
-git push origin main
+# MP4C Health Protocol App
+
+This repository contains a minimal Kotlin Android project. It demonstrates
+internationalization with German (default), English and Turkish translations.
+All resources are plain text. No binaries or media files are included.
+
+## Build
+
+```bash
+./gradlew assembleDebug
+```
+
+## Lizenz
+
+Diese Beispiel-App steht unter der MIT-Lizenz.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.mp4c.health"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.mp4c.health"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.9.0")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mp4c.health">
+
+    <application
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/mp4c/health/MainActivity.kt
+++ b/app/src/main/java/com/mp4c/health/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.mp4c.health
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <!-- Layout Content Placeholder -->
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MP4C Health Protocol</string>
+</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MP4C Saglik Protokolü</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MP4C Gesundheitsprotokoll</string>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("com.android.application") version "8.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "MP4CHealthApp"
+include(":app")


### PR DESCRIPTION
## Summary
- add Gradle build scripts and settings
- add basic app module with MainActivity
- provide translations for German, English and Turkish
- document project in README
- add .gitignore

## Testing
- `gradle tasks --all --dry-run` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d0abca1483319d24d85c18878c61